### PR TITLE
Create new download directory if not exists

### DIFF
--- a/src/main/java/org/monarchinitiative/biodownload/BioDownloaderBuilder.java
+++ b/src/main/java/org/monarchinitiative/biodownload/BioDownloaderBuilder.java
@@ -3,6 +3,7 @@ package org.monarchinitiative.biodownload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.LinkedList;
@@ -192,6 +193,14 @@ public class BioDownloaderBuilder {
         StringBuilder sb = new StringBuilder();
         if (resources.size() == 0) {
             sb.append("A name and a URL need to be included. Please pick one of the available options or add your custom name and URL.\n");
+        }
+        File destinationDirectoryFile = destinationPath.toFile();
+        if (! destinationDirectoryFile.exists()) {
+            logger.info("Creating new download directory at {}", destinationDirectoryFile.getAbsoluteFile());
+            boolean result = destinationDirectoryFile.mkdirs();
+            if (! result) {
+                sb.append("Could not create new destination directory for downloads");
+            }
         }
         if (!destinationPath.toFile().isDirectory()) {
             sb.append("Path must be a directory.\n");

--- a/src/main/java/org/monarchinitiative/biodownload/BioDownloaderImpl.java
+++ b/src/main/java/org/monarchinitiative/biodownload/BioDownloaderImpl.java
@@ -50,11 +50,11 @@ class BioDownloaderImpl implements IBioDownloader {
                 File file = optionalFile.get();
                 downloadedFiles.add(file);
                 logger.info("[INFO] Downloaded \"{}\" file to \"{}\" ({} files were previously downloaded)\n",
-                        file.getName(), downloadDirectory.toString(), numberOfFiles);
+                        file.getName(), downloadDirectory, numberOfFiles);
                 numberOfFiles++;
             } else {
                 logger.info("[INFO] No file with the name \"{}\" downloaded to \"{}\" ({} files were previously downloaded)\n",
-                        resource.getName(), downloadDirectory.toString(), numberOfFiles);
+                        resource.getName(), downloadDirectory, numberOfFiles);
             }
         }
         return downloadedFiles;

--- a/src/main/java/org/monarchinitiative/biodownload/DownloadableResource.java
+++ b/src/main/java/org/monarchinitiative/biodownload/DownloadableResource.java
@@ -100,7 +100,7 @@ public class DownloadableResource {
     public String toString() {
         return "DownloadableResource{" +
                 "name='" + name + '\'' +
-                ", url=" + url.toString() +
+                ", url=" + url +
                 '}';
     }
 }

--- a/src/main/java/org/monarchinitiative/biodownload/FileDownloader.java
+++ b/src/main/java/org/monarchinitiative/biodownload/FileDownloader.java
@@ -101,8 +101,7 @@ class FileDownloader {
         try {
             int connectionTimeout = 5000; // 5 seconds should be more than enough to connect to a server
             final String TEXTPLAIN_REQUEST_TYPE = ", text/plain; q=0.1";
-            String actualAcceptHeaders = TEXTPLAIN_REQUEST_TYPE;
-            URLConnection connection = connect(src.openConnection(), connectionTimeout, actualAcceptHeaders, new HashSet<>());
+            URLConnection connection = connect(src.openConnection(), connectionTimeout, TEXTPLAIN_REQUEST_TYPE, new HashSet<>());
             final int fileSize = connection.getContentLength();
             in = new BufferedInputStream(connection.getInputStream());
             out = new FileOutputStream(dest);


### PR DESCRIPTION
The validate function was not allowing the code for creating a new directory (if not exists) to run, so I added this. I did not remove the previous code (in FileDownloader), but it is not necessary anymore.