### PR TITLE
Download files without compressing them

### DIFF
--- a/src/main/java/org/monarchinitiative/biodownload/FileDownloader.java
+++ b/src/main/java/org/monarchinitiative/biodownload/FileDownloader.java
@@ -143,6 +143,8 @@ class FileDownloader {
         if (conn instanceof HttpURLConnection) {
             // follow redirects to HTTPS
             HttpURLConnection con = (HttpURLConnection) conn;
+            // we set the Accept encoding property to empty to force the download of files unzipped
+            conn.setRequestProperty("Accept-Encoding", "");
             con.connect();
             int responseCode = con.getResponseCode();
             // redirect


### PR DESCRIPTION
*fix issue #28 : hp.json can be downloaded uncompressed with this commit