### PR TITLE
Update HGNC URL

### DIFF
--- a/src/main/resources/resource-url.properties
+++ b/src/main/resources/resource-url.properties
@@ -7,7 +7,7 @@ gencode.grch38.v38.basic=https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_hum
 gencode.grch38.v38.comprehensive=https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_38/gencode.v38.annotation.gtf.gz
 gencode.grch38.v39.basic=https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_39/gencode.v39.basic.annotation.gtf.gz
 gencode.grch38.v39.comprehensive=https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_39/gencode.v39.annotation.gtf.gz
-hgnc.complete-set=ftp://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt
+hgnc.complete-set=https://storage.googleapis.com/public-download-files/hgnc/tsv/tsv/hgnc_complete_set.txt
 gene-info.human=ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
 
 # Proteins

--- a/src/test/java/org/monarchinitiative/biodownload/BioDownloaderTest.java
+++ b/src/test/java/org/monarchinitiative/biodownload/BioDownloaderTest.java
@@ -60,7 +60,11 @@ public class BioDownloaderTest {
 
     @Test
     public void testNewNameFileDownload() throws Exception {
-        BioDownloader bioDownloader = BioDownloader.builder(resourcePath).overwrite(true).custom("hp_new.json", new URL("https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.json")).build();
+        URL hpoUrl = new URL("http://purl.obolibrary.org/obo/hp.json");
+        BioDownloader bioDownloader = BioDownloader.builder(resourcePath)
+                .overwrite(true)
+                .custom("hp_new.json", hpoUrl)
+                .build();
         List<File> downloadedFile = bioDownloader.download();
         assertEquals("hp_new.json", downloadedFile.get(0).getName());
 


### PR DESCRIPTION
Update the HGNC complete set URL to point to new Google Cloud location.

Use HPO PURL in tests instead of raw GitHub asset.